### PR TITLE
Add PlatformOnly annotations

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,8 @@ toc::[]
 
 === Added
 
+* `AndroidOnly`, `JvmOnly` and `iOSOnly` annotations for common
+
 === Changed
 
 === Removed

--- a/test-util/build.gradle.kts
+++ b/test-util/build.gradle.kts
@@ -69,6 +69,8 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation(Dependency.multiplatform.kotlin.stdlibJdk8)
+
+                implementation(Dependency.multiplatform.kotlin.testJvmJunit)
             }
         }
         val jvmTest by getting {
@@ -82,6 +84,8 @@ kotlin {
             dependencies {
                 implementation(Dependency.multiplatform.kotlin.stdlibNative)
                 implementation(Dependency.multiplatform.d4l.sdkObjcUtil)
+
+                implementation(Dependency.multiplatform.kotlin.testCommonAnnotations)
             }
         }
 

--- a/test-util/src/androidMain/kotlin/care/data4life/sdk/util/test/annotation/PlatformOnly.kt
+++ b/test-util/src/androidMain/kotlin/care/data4life/sdk/util/test/annotation/PlatformOnly.kt
@@ -1,0 +1,7 @@
+package care.data4life.sdk.util.test.annotation
+
+import org.junit.Ignore
+
+actual annotation class AndroidOnly
+actual typealias JvmOnly = Ignore
+actual typealias iOSOnly = Ignore

--- a/test-util/src/androidTest/kotlin/care/data4life/sdk/util/test/annotation/PlatformRunner.kt
+++ b/test-util/src/androidTest/kotlin/care/data4life/sdk/util/test/annotation/PlatformRunner.kt
@@ -1,0 +1,15 @@
+package care.data4life.sdk.util.test.annotation
+
+actual object PlatformRunner {
+    actual fun androidOnly(): String {
+        return "test"
+    }
+
+    actual fun jvmOnly(): String {
+        throw RuntimeException()
+    }
+
+    actual fun iOSOnly(): String {
+        throw RuntimeException()
+    }
+}

--- a/test-util/src/commonMain/kotlin/care/data4life/sdk/util/test/annotation/PlatformOnly.kt
+++ b/test-util/src/commonMain/kotlin/care/data4life/sdk/util/test/annotation/PlatformOnly.kt
@@ -1,0 +1,5 @@
+package care.data4life.sdk.util.test.annotation
+
+expect annotation class AndroidOnly()
+expect annotation class JvmOnly()
+expect annotation class iOSOnly()

--- a/test-util/src/commonTest/kotlin/care/data4life/sdk/util/test/annotation/PlatformOnlyTest.kt
+++ b/test-util/src/commonTest/kotlin/care/data4life/sdk/util/test/annotation/PlatformOnlyTest.kt
@@ -1,0 +1,39 @@
+package care.data4life.sdk.util.test.annotation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlatformOnlyTest {
+    @Test
+    @AndroidOnly
+    fun `Given it is AndroidOnly annotated it runs only on Android`() {
+        assertEquals(
+            actual = PlatformRunner.androidOnly(),
+            expected = "test"
+        )
+    }
+
+    @Test
+    @JvmOnly
+    fun `Given it is JvmOnly annotated it runs only on Jvm`() {
+        assertEquals(
+            actual = PlatformRunner.jvmOnly(),
+            expected = "test"
+        )
+    }
+
+    @Test
+    @iOSOnly
+    fun `Given it is iOSOnly annotated it runs only on iOS`() {
+        assertEquals(
+            actual = PlatformRunner.iOSOnly(),
+            expected = "test"
+        )
+    }
+}
+
+expect object PlatformRunner {
+    fun androidOnly(): String
+    fun jvmOnly(): String
+    fun iOSOnly(): String
+}

--- a/test-util/src/iosMain/kotlin/care/data4life/sdk/util/test/annotation/PlatformOnly.kt
+++ b/test-util/src/iosMain/kotlin/care/data4life/sdk/util/test/annotation/PlatformOnly.kt
@@ -1,0 +1,7 @@
+package care.data4life.sdk.util.test.annotation
+
+import kotlin.test.Ignore
+
+actual typealias AndroidOnly = Ignore
+actual typealias JvmOnly = Ignore
+actual annotation class iOSOnly

--- a/test-util/src/iosTest/kotlin/care/data4life/sdk/util/test/annotation/PlatformRunner.kt
+++ b/test-util/src/iosTest/kotlin/care/data4life/sdk/util/test/annotation/PlatformRunner.kt
@@ -1,0 +1,15 @@
+package care.data4life.sdk.util.test.annotation
+
+actual object PlatformRunner {
+    actual fun androidOnly(): String {
+        throw RuntimeException()
+    }
+
+    actual fun jvmOnly(): String {
+        throw RuntimeException()
+    }
+
+    actual fun iOSOnly(): String {
+        return "test"
+    }
+}

--- a/test-util/src/jvmMain/kotlin/care/data4life/sdk/util/test/annotation/PlatformOnly.kt
+++ b/test-util/src/jvmMain/kotlin/care/data4life/sdk/util/test/annotation/PlatformOnly.kt
@@ -1,0 +1,7 @@
+package care.data4life.sdk.util.test.annotation
+
+import org.junit.Ignore
+
+actual typealias AndroidOnly = Ignore
+actual annotation class JvmOnly
+actual typealias iOSOnly = Ignore

--- a/test-util/src/jvmTest/kotlin/care/data4life/sdk/util/test/annotation/PlatformRunner.kt
+++ b/test-util/src/jvmTest/kotlin/care/data4life/sdk/util/test/annotation/PlatformRunner.kt
@@ -1,0 +1,15 @@
+package care.data4life.sdk.util.test.annotation
+
+actual object PlatformRunner {
+    actual fun androidOnly(): String {
+        throw RuntimeException()
+    }
+
+    actual fun jvmOnly(): String {
+        return "test"
+    }
+
+    actual fun iOSOnly(): String {
+        throw RuntimeException()
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This add annotations, to run test only on specific platforms in order to enable parallel development on KMP without having the need to implement everything right away on all target platforms.

## How is it being implemented?
<!--- Please describe in detail how you implemented your changes. -->
<!--- Include details of your implemented environment, and the tests you ran to -->
It adds `AndroidOnly`, `JvmOnly` and `iOSOnly` annotations, which are ignored on the non target platforms and be a re noop on the the target platform.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have updated the changelog accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
